### PR TITLE
Export more of the API for use by upload_graphql_safelist.js.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,27 @@
-// This file is to be imported for client code using the network interface.
+// This file is to be imported for client code.
+import {
+    ExtractGQL,
+    ExtractGQLOptions,
+} from './src/ExtractGQL';
+
+import {
+    QueryTransformer,
+} from './src/common';
+
+import {
+    addTypenameTransformer,
+} from './src/queryTransformers';
+
 import {
   PersistedQueryNetworkInterface,
   addPersistedQueries,
 } from './src/network_interface/ApolloNetworkInterface';
 
 export {
+  ExtractGQL,
+  ExtractGQLOptions,
+  QueryTransformer,    
+  addTypenameTransformer,
   PersistedQueryNetworkInterface,
   addPersistedQueries,
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,2 +1,5 @@
+import { ExtractGQL, ExtractGQLOptions } from './src/ExtractGQL';
+import { QueryTransformer } from './src/common';
+import { addTypenameTransformer } from './src/queryTransformers';
 import { PersistedQueryNetworkInterface, addPersistedQueries } from './src/network_interface/ApolloNetworkInterface';
-export { PersistedQueryNetworkInterface, addPersistedQueries, };
+export { ExtractGQL, ExtractGQLOptions, QueryTransformer, addTypenameTransformer, PersistedQueryNetworkInterface, addPersistedQueries, };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.addPersistedQueries = exports.PersistedQueryNetworkInterface = void 0;
+exports.addPersistedQueries = exports.PersistedQueryNetworkInterface = exports.addTypenameTransformer = exports.ExtractGQL = void 0;
+var ExtractGQL_1 = require("./src/ExtractGQL");
+Object.defineProperty(exports, "ExtractGQL", { enumerable: true, get: function () { return ExtractGQL_1.ExtractGQL; } });
+var queryTransformers_1 = require("./src/queryTransformers");
+Object.defineProperty(exports, "addTypenameTransformer", { enumerable: true, get: function () { return queryTransformers_1.addTypenameTransformer; } });
 var ApolloNetworkInterface_1 = require("./src/network_interface/ApolloNetworkInterface");
 Object.defineProperty(exports, "PersistedQueryNetworkInterface", { enumerable: true, get: function () { return ApolloNetworkInterface_1.PersistedQueryNetworkInterface; } });
 Object.defineProperty(exports, "addPersistedQueries", { enumerable: true, get: function () { return ApolloNetworkInterface_1.addPersistedQueries; } });

--- a/lib/index.js.map
+++ b/lib/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../index.ts"],"names":[],"mappings":";;;AACA,yFAGwD;AAGtD,+GALA,uDAA8B,OAKA;AAC9B,oGALA,4CAAmB,OAKA"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../index.ts"],"names":[],"mappings":";;;AACA,+CAG0B;AAgBxB,2FAlBE,uBAAU,OAkBF;AAVZ,6DAEiC;AAW/B,uGAZE,0CAAsB,OAYF;AATxB,yFAGwD;AAOtD,+GATA,uDAA8B,OASA;AAC9B,oGATA,4CAAmB,OASA"}


### PR DESCRIPTION
## Summary:
These are probably API components that the author considered internal,
but given that this code hasn't changed in over 3 years I feel the API
is probably pretty set at this point.

The motivation for this is to allow us to run persistgraphql, as part
of our safelist-upload process, without having to shell out to run it
as a binary.  Secondary benefits mean not having to involve temporary
files, which the binary API requires.

Issue: none

## Test plan:
Will try this in webapp!